### PR TITLE
Update the map on init, add palette

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -371,7 +371,8 @@ int main()
 		// reset unpack options
 		glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-		glPixelStorei(GL_PACK_ROW_LENGTH, 0);
+		glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+		glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 0);
 
 		glBindTexture(GL_TEXTURE_2D, image_texture);
 		gl_error = glGetError();

--- a/main.cpp
+++ b/main.cpp
@@ -278,14 +278,14 @@ int main()
 //	std::cout << "rv_map_init" << std::endl;
 //	rv_map_init(context, map_desc);
 
-//	rv_rect update_region {
-//		.x = 0,
-//		.y = 0,
-//		.width = map_width,
-//		.height = map_height,
-//	};
-//	std::cout << "rv_map_request_update" << std::endl;
-//	rv_map_request_update(context, update_region);
+	rv_rect update_region {
+		.x = 0,
+		.y = 0,
+		.width = map_width,
+		.height = map_height,
+	};
+	std::cout << "rv_map_request_update" << std::endl;
+	rv_map_request_update(context, update_region);
 
 
 	float angle = -M_PI / 2;

--- a/main.cpp
+++ b/main.cpp
@@ -232,6 +232,14 @@ int main()
 		material_end_offsets[i] = material_bytes[i * sizeof (uint32_t) + 1];
 	}
 
+	//TODO: load from file
+	uint8_t palette[0x300] = {};
+	for (int i=0; i<0x100; ++i) {
+		palette[3*i+0] = 0x80 + i * 17;
+		palette[3*i+1] = 0x80 + i * 19;
+		palette[3*i+2] = 0x80 + i * 23;
+	}
+
 	rv_gl_functor gl_functor = (rv_gl_functor)SDL_GL_GetProcAddress;
 
 	rv_init_descriptor init_desc = {
@@ -250,6 +258,7 @@ int main()
 		.material_begin_offsets = material_begin_offsets,
 		.material_end_offsets = material_end_offsets,
 		.material_count = material_count,
+		.palette = palette,
 	};
 
 	std::cout << "rv_map_init" << std::endl;
@@ -288,7 +297,7 @@ int main()
 	rv_map_request_update(context, update_region);
 
 
-	float angle = -M_PI / 2;
+	float angle = -M_PI / 3;
 	float angle_step = M_PI/30.0f;
 	float move_step = 10;
 

--- a/vange_rs.h
+++ b/vange_rs.h
@@ -54,6 +54,9 @@ struct rv_map_description {
 
 	// 8 for world, 16 for escave
 	int32_t material_count;
+
+	// RGB for 256 colors
+	uint8_t* palette;
 };
 
 // TODO: or it could be left, bottom, right, top


### PR DESCRIPTION
Depends on https://github.com/kvark/vange-rs/pull/174 (last commit about the palette)
Follows up on #2 to fix the silly mistake of using `PACK_ROW_LENGTH` instead of `UNPACK_ROW_LENGTH`.

Enables the original map update on init. The FFI expects that any visible map region is updated before it's rendered, so this initial call is needed.